### PR TITLE
lncli: read password from stdin till EOF in unlock

### DIFF
--- a/cmd/lncli/cmd_walletunlocker.go
+++ b/cmd/lncli/cmd_walletunlocker.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"strconv"
@@ -469,7 +470,9 @@ var unlockCommand = cli.Command{
 				"a file that can be read by another user. " +
 				"This flag should only be used in " +
 				"combination with some sort of password " +
-				"manager or secrets vault.",
+				"manager or secrets vault. The password will " +
+				"be read from standard input until EOF " +
+				"(End of File) is encountered.",
 		},
 		statelessInitFlag,
 	},
@@ -491,11 +494,25 @@ func unlock(ctx *cli.Context) error {
 	// password manager. If the user types the password instead, it will be
 	// echoed in the console.
 	case ctx.IsSet("stdin"):
-		reader := bufio.NewReader(os.Stdin)
-		pw, err = reader.ReadBytes('\n')
+		// Copy the password from standard input to the buffer until
+		// EOF (End of File) is encountered.
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, os.Stdin); err != nil {
+			return err
+		}
+		pw = buf.Bytes()
 
-		// Remove carriage return and newline characters.
-		pw = bytes.Trim(pw, "\r\n")
+		// Remove carriage return.
+		pw = bytes.Trim(pw, "\r")
+
+		// Check if the provided password has leading or trailing
+		// newline characters, then issue a warning since they will
+		// not be trimmed.
+		if !bytes.Equal(pw, bytes.Trim(pw, "\n")) {
+			fmt.Printf("WARNING: Password contains leading or" +
+				"trailing newline characters and they will " +
+				"not be trimmed.\n")
+		}
 
 	// Read the password from a terminal by default. This requires the
 	// terminal to be a real tty and will fail if a string is piped into


### PR DESCRIPTION
## Change Description
Description of change / link to associated issue.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ] Any new lncli commands have appropriate tags in the comments for the rpc in the proto file.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
